### PR TITLE
falsche zeit

### DIFF
--- a/Vorlesungen/Woche03/Objektorientierung_korrigiert.sbv
+++ b/Vorlesungen/Woche03/Objektorientierung_korrigiert.sbv
@@ -192,7 +192,7 @@ oder als Blackbox ansieht.
 0:03:50.370,0:03:53.010
 Das ist beides prinzipiell abgedeckt.
 
-0:03:57.360,0:03:57.857
+0:03:53.010,0:03:57.857
 In Hinsicht des Formalitätsgrades 
 bestenfalls semi-formal.
 


### PR DESCRIPTION
Wodurch an einer Stelle erst keine und dann ganz kurz die falschen Untertitel angezeigt werden.

